### PR TITLE
Fix Custom Exception Traceback Issue #3

### DIFF
--- a/exception/custom_exception.py
+++ b/exception/custom_exception.py
@@ -10,7 +10,7 @@ class DocumentPortalException(Exception):
         self.file_name=exc_tb.tb_frame.f_code.co_filename
         self.lineno=exc_tb.tb_lineno
         self.error_message=str(error_message)
-        self.traceback_str = ''.join(traceback.format_exception(*error_details.exc_info())) 
+        self.traceback_str = ''.join(traceback.format_exception(*sys.exc_info())) 
         
     def __str__(self):
        return f"""


### PR DESCRIPTION
## Changes Done
- Replace error_details.exc_info() with sys.exc_info() in DocumentPortalException
- Fixes NameError where error_details was not defined in __init__ method
- Ensures proper traceback formatting for custom exceptions
- Validated with test case in __main__ block

Before Fix:
<img width="806" height="181" alt="image" src="https://github.com/user-attachments/assets/a95bb3ce-ccd9-45d6-9d5d-5b4eec3b04e8" />

After Fix:
<img width="741" height="280" alt="image" src="https://github.com/user-attachments/assets/614b32bd-d8e4-43ae-bc1a-121860b289e7" />

Resolves #3